### PR TITLE
chore: trigger blue/green deployment on nginx demo

### DIFF
--- a/k8s-app/go-demo/rollout.yaml
+++ b/k8s-app/go-demo/rollout.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: go-demo
-          image: golang:1.23-alpine
+          image: golang:1.24-alpine
           command: ["/bin/sh"]
           args:
             - -c


### PR DESCRIPTION
- updates the go version